### PR TITLE
Multiline prop description

### DIFF
--- a/lib/templates/markdown.handlebars
+++ b/lib/templates/markdown.handlebars
@@ -13,7 +13,7 @@
 Property | Type | Default value | Description
 :--- | :--- | :--- | :---
 {{#each props}}
-`{{name}}`|{{type}}|{{#if required}}_required_{{else}}{{default}}{{/if}}|{{description}}
+`{{name}}`|{{type}}|{{#if required}}_required_{{else}}{{default}}{{/if}}|{{{description}}}
 {{/each}}
 
 {{/if}}

--- a/lib/utils/parse-files.js
+++ b/lib/utils/parse-files.js
@@ -76,7 +76,6 @@ function replaceNewlinesInPropDescriptions(components) {
       return comp
     }
     for (const propName of Object.keys(comp.props)) {
-      console.log(propName)
       comp.props[propName].description =
         (comp.props[propName].description || '').replace(/\n/g, '<br />')
     }

--- a/lib/utils/parse-files.js
+++ b/lib/utils/parse-files.js
@@ -21,7 +21,9 @@ exports.parseFiles = ({ options, callback }) => {
       }
 
       try {
-        const components = parse(content, resolver.findAllExportedComponentDefinitions)
+        const components = replaceNewlinesInPropDescriptions(
+          parse(content, resolver.findAllExportedComponentDefinitions)
+        )
 
         files.push({ filename, components })
       } catch (e) {
@@ -66,4 +68,18 @@ function getOptionsFeedback(options) {
   }
 
   return sentences.join(' - ')
+}
+
+function replaceNewlinesInPropDescriptions(components) {
+  return components.map(comp => {
+    if (!comp.props) {
+      return comp
+    }
+    for (const propName of Object.keys(comp.props)) {
+      console.log(propName)
+      comp.props[propName].description =
+        (comp.props[propName].description || '').replace(/\n/g, '<br />')
+    }
+    return comp
+  })
 }


### PR DESCRIPTION
Multiline prop descriptions broke the generated markdown table.
This PR does the following:
- when parsing doc comments, replace all newline characters `"\n"` in prop descriptions with `"<br />"`
- handlebars template doesn't HTML-escape prop descriptions, to allow rendering of `<br />`;
  this also has the side-effect of rendering markdown from the doc comment, which I find positive